### PR TITLE
Update the ordering of steps in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,14 @@ Some features are still missing.
 	- Use `venv\Scripts\activate` on Windows.
 - Install the required packages (mainly Django): `pip3 install -r requirements.txt`
 	- Are you getting `fatal error: Python.h: No such file or directory`? Try installing `python-dev` libraries first (e.g. `sudo apt-get install python-dev`).
-- Make a superuser with `python manage.py createsuperuser`
 - Create a folder for logs to go in: `mkdir logs`
 - **Fix all the configuration options, secret keys and credentials:**
 	- the SECRET_KEY and SITE_PASSWORD in `puzzlord/settings.py` (the SECRET_KEY should be a highly secure random string, which Django uses for hashes, CSRF tokens, and such; the SITE_PASSWORD is what you will give out to users to let them register accounts)
 	- the sender and reply-to email in `puzzle_editing/messaging.py`
 	- the SECRET_KEY and email credentials in `settings/base.py`
 	- the hosts in `settings/staging.py` and `settings/prod.py`
+- Make sure the database schema is up to date with `python manage.py migrate`
+- Make a superuser with `python manage.py createsuperuser`
 - Install pre-commit hooks `pre-commit install` (may need to `pip3 install pre-commit` first)
 - Start the development server with `python manage.py runserver`
 - If you get a warning (red text) about making migrations run `python manage.py migrate`


### PR DESCRIPTION
I had to perform the operations in this order in order to get the dev
environment working. (Since I'm just running a development instance,
I'm not changing any of the configuration options from the default for
now, but I assume you'd want to do that before running the database
migrations)